### PR TITLE
Introducing run and waitFor for async testing

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -216,6 +216,42 @@ Behavioral testing, that is, asserting that certain functions are called rather 
       expect(decrement_luck_was_called).to(equal, true);
     });
 
+## Asynchronous Testing
+
+Asynchronous testing is done by specifying one or more `waitFor`/`run` functions inside an `it`.
+
+    it("tests an asynchronous function", function() {
+      function asyncSum(lhs, rhs, result) {
+        window.setTimeout(function() {
+          result.sum = lhs + rhs;
+        }, 250);
+      }
+
+      var result = {};
+
+      run(function() {
+        asyncSum(2, 3, result);
+      });
+
+      waitFor({
+        description: "waiting for asyncSum to give a result timed out.",
+        run: function() {
+          return result.sum !== undefined;
+        },
+        timeout: 1500
+      });
+
+      /* An alternative short-hand waitFor function with default description and timeout (of 5000ms) would be to use:
+      waitFor(function() {
+        return result.sum !== undefined;
+      });
+      */
+
+      run(function() {
+        assertThat(result.sum, 5);
+      });
+    });
+
 # How to Test the DOM
 
 The simplest way to test the DOM is to have a special DOM node in your `suite.html` file. Have all tests insert nodes into this node; have a global `before` reset the node between tests.

--- a/lib/screw.behaviors.js
+++ b/lib/screw.behaviors.js
@@ -50,6 +50,7 @@
         function trigger(type, description) {
           self.trigger(type, description);
           self.fn('parent').fn('run_afters');
+          setTimeout(function() {$(Screw).dequeue()}, 0);
         }
 
         function runJob(job, remainingJobs) {
@@ -103,7 +104,6 @@
         $(Screw)
           .queue(function() {
             self.fn('run');
-            setTimeout(function() {$(Screw).dequeue()}, 0);
           });
       },
 

--- a/lib/screw.behaviors.js
+++ b/lib/screw.behaviors.js
@@ -45,28 +45,68 @@
       },
       
       run: function() {
-        try {
+        var self = $(this);
+
+        function trigger(type, description) {
+          self.trigger(type, description);
+          self.fn('parent').fn('run_afters');
+        }
+
+        function runJob(job, remainingJobs) {
           try {
-            $(this).fn('parent').fn('run_befores');
-            $(this).data('screwunit.run')();
-          } finally {
-            $(this).fn('parent').fn('run_afters');
+            job();
+            if(remainingJobs.length > 0) {
+              runAsyncJobs(remainingJobs);
+            } else {
+              trigger('passed')
+            }
+          } catch(e) {
+            trigger('failed', [e]);
           }
-          $(this).trigger('passed');
-        } catch(e) {
-          $(this).trigger('failed', [e]);
+        }
+
+        function runWaitFor(waitForJob, timeWaited, remainingJobs) {
+          window.setTimeout(function() {
+            if(waitForJob()) {
+              runAsyncJobs(remainingJobs);
+            } else if(timeWaited < waitForJob.timeout) {
+              runWaitFor(waitForJob, timeWaited + 250, remainingJobs);
+            } else {
+              trigger('failed', [waitForJob.description]);
+            }
+          }, 250);
+        }
+
+        function runAsyncJobs(asyncJobs) {
+          if(asyncJobs.length > 0) {
+            var nextJob = asyncJobs[0];
+            var remainingJobs = asyncJobs.slice(1);
+
+            if(nextJob.type === "waitFor") {
+              runWaitFor(nextJob, 0, remainingJobs);
+            } else {
+              runJob(nextJob, remainingJobs);
+            }
+          }
+        }
+
+        $(this).fn('parent').fn('run_befores');
+        if($(this).data('screwunit.run')) {
+          runJob($(this).data('screwunit.run'), []);
+        } else {
+          runAsyncJobs($(this).data('screwunit.asyncJobs'));
         }
       },
-      
+
       enqueue: function() {
         var self = $(this).trigger('enqueued');
         $(Screw)
           .queue(function() {
             self.fn('run');
-            setTimeout(function() { $(Screw).dequeue() }, 0);
+            setTimeout(function() {$(Screw).dequeue()}, 0);
           });
       },
-      
+
       selector: function() {
         return $(this).fn('parent').fn('selector')
           + ' > .its > .it:eq(' + $(this).parent('.its').children('.it').index(this) + ')';

--- a/lib/screw.behaviors.js
+++ b/lib/screw.behaviors.js
@@ -89,6 +89,8 @@
             } else {
               runJob(nextJob, remainingJobs);
             }
+          } else {
+            trigger('passed');
           }
         }
 

--- a/lib/screw.behaviors.js
+++ b/lib/screw.behaviors.js
@@ -67,15 +67,16 @@
         }
 
         function runWaitFor(waitForJob, timeWaited, remainingJobs) {
+          var pollingTimeout = 25; // waitFor is polled every x ms.
           window.setTimeout(function() {
             if(waitForJob()) {
               runAsyncJobs(remainingJobs);
             } else if(timeWaited < waitForJob.timeout) {
-              runWaitFor(waitForJob, timeWaited + 250, remainingJobs);
+              runWaitFor(waitForJob, timeWaited + pollingTimeout, remainingJobs);
             } else {
               trigger('failed', [waitForJob.description]);
             }
-          }, 250);
+          }, pollingTimeout);
         }
 
         function runAsyncJobs(asyncJobs) {

--- a/lib/screw.behaviors.js
+++ b/lib/screw.behaviors.js
@@ -45,25 +45,16 @@
       },
       
       run: function() {
-        var exception_during_spec;
         try {
           try {
             $(this).fn('parent').fn('run_befores');
             $(this).data('screwunit.run')();
-          } catch(e) {
-            exception_during_spec = e;
-            throw e;
-          }
-          finally {
+          } finally {
             $(this).fn('parent').fn('run_afters');
           }
           $(this).trigger('passed');
-        } catch(any_exception) {
-          // If exceptions are thrown both during and after the spec,
-          // report the one thrown first
-          // (because the one thrown afterwards is likely to be a subsequent error)
-          var exception_to_report = exception_during_spec || any_exception;
-          $(this).trigger('failed', [exception_to_report]);
+        } catch(e) {
+          $(this).trigger('failed', [e]);
         }
       },
       

--- a/lib/screw.builder.js
+++ b/lib/screw.builder.js
@@ -41,7 +41,7 @@ var Screw = (function($) {
         var it = $('<li class="it"></li>')
           .append($('<h2></h2>').text(name));
 
-        if(/(waitFor|run)\(\s*function/.test(fn.toString())) {
+        if(/(waitFor|run)\s*\(\s*/.test(fn.toString().replace(/"((\\")|[^"])*"/g, "").replace(/'((\\')|[^'])*'/g, ""))) {
           it.data('screwunit.asyncJobs', []);
 
           this.context.push(it);

--- a/lib/screw.builder.js
+++ b/lib/screw.builder.js
@@ -39,12 +39,45 @@ var Screw = (function($) {
 
       it: function(name, fn) {
         var it = $('<li class="it"></li>')
-          .append($('<h2></h2>').text(name))
-          .data('screwunit.run', fn);
+          .append($('<h2></h2>').text(name));
+
+        if(/(waitFor|run)\(\s*function/.test(fn.toString())) {
+          it.data('screwunit.asyncJobs', []);
+
+          this.context.push(it);
+          fn.call();
+          this.context.pop();
+        } else {
+          it.data('screwunit.run', fn);
+        }
 
         this.context[this.context.length-1]
           .children('.its')
             .append(it);
+      },
+
+      waitFor: function(fn) {
+        var timeout = 5000; // default timeout is 5 seconds
+        var description = "waitFor job didn't complete in time ("+timeout+"ms timeout exceeded)"; // default description
+        var options;
+
+        if($.isPlainObject(fn)) {
+          options = fn;
+          fn = options.run;
+        }
+
+        var ctx = this.context[this.context.length-1];
+        $.extend(fn, {
+          type: "waitFor",
+          description: description,
+          timeout: timeout
+        }, options);
+        ctx.data('screwunit.asyncJobs').push(fn);
+      },
+
+      run: function(fn) {
+        var ctx = this.context[this.context.length-1];
+        ctx.data('screwunit.asyncJobs').push(fn);
       },
 
       before: function(fn) {


### PR DESCRIPTION
Asynchronous testing is done by specifying one or more `waitFor`/`run` functions inside an `it`.

``` javascript
it("tests an asynchronous function", function() {
  function asyncSum(lhs, rhs, result) {
    window.setTimeout(function() {
      result.sum = lhs + rhs;
    }, 250);
  }

  var result = {};

  run(function() {
    asyncSum(2, 3, result);
  });

  waitFor({
    description: "waiting for asyncSum to give a result timed out.",
    run: function() {
      return result.sum !== undefined;
    },
    timeout: 1500
  });

  /* An alternative short-hand waitFor function with default description and timeout (of 5000ms) would be to use:
  waitFor(function() {
    return result.sum !== undefined;
  });
  */

  run(function() {
    assertThat(result.sum, 5);
  });
});
```

Commits are mainly by @EleotleCram (see https://github.com/EleotleCram/screw-unit )
